### PR TITLE
Fix incorrect cache data structure

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const pify = require('pify');
 const plist = require('plist');
 const tempfile = require('tempfile');
 const Conf = require('conf');
+const CacheConf = require('cache-conf');
 const env = require('./lib/env');
 const mainFile = require('./lib/main-file');
 
@@ -46,7 +47,7 @@ module.exports = options => {
 		cwd: opts.workflow_data
 	});
 
-	alfyTest.cache = new Conf({
+	alfyTest.cache = new CacheConf({
 		configName: 'cache',
 		cwd: opts.workflow_cache
 	});

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "alfy"
   ],
   "dependencies": {
+    "cache-conf": "^0.3.0",
     "conf": "^0.11.2",
     "execa": "^0.4.0",
     "find-up": "^1.1.2",


### PR DESCRIPTION
Use case: get all cache items with:
```js
[...alfy.cache]
```

`alfy` returns:
```js
[['name', {data: 'value'}]]
```

while `alfy-test` returns:
```js
[['name', 'value']]
```